### PR TITLE
Add support for numbers

### DIFF
--- a/Sources/SnappThemingDesignTokensSupport/Convertor/DesignTokensConverter.swift
+++ b/Sources/SnappThemingDesignTokensSupport/Convertor/DesignTokensConverter.swift
@@ -221,7 +221,9 @@ public struct DesignTokensConverter: Sendable {
             return .typography(fontWeightMapping: configuration.fontWeightMapping)
         case .gradient:
             return .gradient(using: configuration.colorHexFormat)
-        case .fontWeight, .number,
+        case .number:
+            return .number
+        case .fontWeight,
             .duration, .shadow, .strokeStyle, .border,
             .cubicBezier, .transition:
             fallthrough

--- a/Sources/SnappThemingDesignTokensSupport/Convertor/Extractor/DesignTokensNumberValueExtractor.swift
+++ b/Sources/SnappThemingDesignTokensSupport/Convertor/Extractor/DesignTokensNumberValueExtractor.swift
@@ -1,0 +1,15 @@
+//
+//  DesignTokensNumberValueExtractor.swift
+//
+//  Created by Volodymyr Voiko on 09.04.2025.
+//
+
+import Foundation
+import SnappDesignTokens
+import SnappTheming
+
+extension DesignTokensTokenValueExtractor {
+    static var number: Self {
+        .init(\.metricsCache) { $0 }
+    }
+}

--- a/Tests/SnappThemingDesignTokensSupportTests/Resources/design.tokens.json
+++ b/Tests/SnappThemingDesignTokensSupportTests/Resources/design.tokens.json
@@ -119,6 +119,14 @@
                     }
                 ]
             }
+        },
+        "number": {
+            "aspect": {
+                "square": {
+                    "$type": "number",
+                    "$value": 1.0
+                }
+            }
         }
     },
     "files": {

--- a/Tests/SnappThemingDesignTokensSupportTests/Resources/expected.snapptheming.json
+++ b/Tests/SnappThemingDesignTokensSupportTests/Resources/expected.snapptheming.json
@@ -48,6 +48,7 @@
     "baseDimensionSpacing20" : 20,
     "semanticFontsizeBody" : 16,
     "semanticFontsizeH1" : 32,
+    "semanticNumberAspectSquare" : 1,
     "semanticSpacingMedium" : 20,
     "semanticSpacingSmall" : 10
   },

--- a/Tests/SnappThemingDesignTokensSupportTests/SnappThemingDesignTokensParserTests.swift
+++ b/Tests/SnappThemingDesignTokensSupportTests/SnappThemingDesignTokensParserTests.swift
@@ -81,13 +81,13 @@ struct SnappThemingDesignTokensParserTests {
                 #"""
                 {
                     "unsupported": {
-                        "$type": "number",
-                        "$value": 0.5
+                        "$type": "fontWeight",
+                        "$value": 100
                     }
                 }
                 """#,
                 DesignTokensConverter.Error.unsupportedToken(
-                    .value(.number(0.5)),
+                    .value(.fontWeight(FontWeightValue(alias: .thin))),
                     forKey: "unsupported"
                 )
             ),


### PR DESCRIPTION
## What
This change introduces explicit support for number type design tokens, enabling them to be correctly extracted and converted into SnappThemingDeclaration's metricsCache. A dedicated extractor for number values has been added, and the DesignTokensConverter has been updated to utilize it. Corresponding test cases and resources have also been updated to reflect this new functionality.

## Why
Previously, number type design tokens were not explicitly handled and would result in an unsupported token error. By adding explicit support, the system can now correctly parse and utilize numerical design tokens, making the theming system more comprehensive and aligned with the DTCG standard for handling primitive value types. This enhances the utility and flexibility of the design token integration.

## Changes
   * New File: Sources/SnappThemingDesignTokensSupport/Convertor/Extractor/DesignTokensNumberValueExtractor.swift was added to handle the extraction of number values.
   * `DesignTokensConverter.swift`: Updated to specifically handle number type tokens, routing them to the new extractor instead of marking them as unsupported.
   * `design.tokens.json` (test resource): Added a new number type token (number.aspect.square) for testing.
   * `expected.snapptheming.json` (test resource): Updated to include the expected output for the newly supported number token.
   * `SnappThemingDesignTokensParserTests.swift`: Modified a test case to reflect that number tokens are now supported, and fontWeight remains unsupported, ensuring correct error handling for other unhandled types.
