### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,34 @@
+---
+name: General issue
+about: Report a reproducible bug or issue
+title: '[Bug] [Feature Request] Short description of the issue'
+labels: ''
+assignees: ''
+---
+
+## 🐞 Expected Behavior  
+<!-- Describe what should happen under normal conditions. -->
+
+## ❌ Actual Behavior  
+<!-- Describe what is currently happening instead of the expected behavior. -->
+
+## 🔄 Steps to Reproduce  
+1. <!-- Step 1: Provide clear instructions to reproduce the issue. -->
+2. <!-- Step 2: Add any additional steps as needed. -->
+3. <!-- Continue listing steps until the issue is fully reproducible. -->
+
+## 📄 Logs / Error Messages  
+<!-- Paste any relevant logs, error messages, or stack traces. -->
+
+## 📸 Screenshots  
+<!-- Attach screenshots or GIFs that help visualize the issue. -->
+
+## 💻 Code Snippets  
+```swift
+// Include relevant code snippets that help reproduce the issue.
+```
+
+## 🛠 System Information
+- **Package Version**: <!-- e.g., 0.1.0 -->
+- **Operating System**: <!-- e.g., macOS 14, iOS 18 -->
+-- **Device / Hardware**: <!-- e.g., iPhone 14 Pro, M1 MacBook -->


### PR DESCRIPTION
## What
This change introduces a new general issue template for the GitHub repository.

## Why
This template standardizes the process of reporting bugs and requesting features, ensuring all necessary information is provided upfront. This helps streamline issue triaging and resolution by providing a clear and consistent reporting structure.

## Changes
* A new file `.github/ISSUE_TEMPLATE/general-issue.md` has been added, containing a template for general issues with predefined sections for expected behavior, actual behavior, steps to reproduce, logs, screenshots, code snippets, and system information.
