### PR TITLE
10 Add sample app to showcase SnappDesigntokens   + SnappTheming  usage

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		2D92B0ED2EF588D800413DED /* SnappThemingDesignTokensSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 2D92B0EC2EF588D800413DED /* SnappThemingDesignTokensSupport */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		2D92B0DD2EF5831D00413DED /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -23,6 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D92B0ED2EF588D800413DED /* SnappThemingDesignTokensSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +70,7 @@
 			);
 			name = Example;
 			packageProductDependencies = (
+				2D92B0EC2EF588D800413DED /* SnappThemingDesignTokensSupport */,
 			);
 			productName = Example;
 			productReference = 2D92B0DD2EF5831D00413DED /* Example.app */;
@@ -94,6 +100,9 @@
 			);
 			mainGroup = 2D92B0D42EF5831D00413DED;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				2D92B0EB2EF588D800413DED /* XCLocalSwiftPackageReference "../../SnappThemingDesignTokensSupport" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2D92B0DE2EF5831D00413DED /* Products */;
 			projectDirPath = "";
@@ -332,6 +341,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		2D92B0EB2EF588D800413DED /* XCLocalSwiftPackageReference "../../SnappThemingDesignTokensSupport" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../SnappThemingDesignTokensSupport;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2D92B0EC2EF588D800413DED /* SnappThemingDesignTokensSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SnappThemingDesignTokensSupport;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 2D92B0D52EF5831D00413DED /* Project object */;
 }

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -1,0 +1,337 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		2D92B0DD2EF5831D00413DED /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		2D92B0DF2EF5831D00413DED /* Example */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Example;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2D92B0DA2EF5831D00413DED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2D92B0D42EF5831D00413DED = {
+			isa = PBXGroup;
+			children = (
+				2D92B0DF2EF5831D00413DED /* Example */,
+				2D92B0DE2EF5831D00413DED /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2D92B0DE2EF5831D00413DED /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2D92B0DD2EF5831D00413DED /* Example.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2D92B0DC2EF5831D00413DED /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D92B0E82EF5831F00413DED /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				2D92B0D92EF5831D00413DED /* Sources */,
+				2D92B0DA2EF5831D00413DED /* Frameworks */,
+				2D92B0DB2EF5831D00413DED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				2D92B0DF2EF5831D00413DED /* Example */,
+			);
+			name = Example;
+			packageProductDependencies = (
+			);
+			productName = Example;
+			productReference = 2D92B0DD2EF5831D00413DED /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2D92B0D52EF5831D00413DED /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2610;
+				LastUpgradeCheck = 2610;
+				TargetAttributes = {
+					2D92B0DC2EF5831D00413DED = {
+						CreatedOnToolsVersion = 26.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 2D92B0D82EF5831D00413DED /* Build configuration list for PBXProject "Example" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2D92B0D42EF5831D00413DED;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 2D92B0DE2EF5831D00413DED /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2D92B0DC2EF5831D00413DED /* Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2D92B0DB2EF5831D00413DED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2D92B0D92EF5831D00413DED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2D92B0E62EF5831F00413DED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 44H75889S4;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		2D92B0E72EF5831F00413DED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 44H75889S4;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2D92B0E92EF5831F00413DED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 44H75889S4;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snappmobile.io.SnappThemingDesignTokensSupport.Example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D92B0EA2EF5831F00413DED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 44H75889S4;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snappmobile.io.SnappThemingDesignTokensSupport.Example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2D92B0D82EF5831D00413DED /* Build configuration list for PBXProject "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D92B0E62EF5831F00413DED /* Debug */,
+				2D92B0E72EF5831F00413DED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D92B0E82EF5831F00413DED /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D92B0E92EF5831F00413DED /* Debug */,
+				2D92B0EA2EF5831F00413DED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2D92B0D52EF5831D00413DED /* Project object */;
+}

--- a/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "ca4c16cf18955963d5cc49328b1a56f38fc48591cc6431920c4cab60ec4fbf72",
+  "pins" : [
+    {
+      "identity" : "snappdesigntokens",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Snapp-Mobile/SnappDesignTokens.git",
+      "state" : {
+        "revision" : "e3c25eea295504250cd078c1b8d499a8f4761995",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "snapptheming",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Snapp-Mobile/SnappTheming.git",
+      "state" : {
+        "revision" : "a4eb1f1ba5f4e2b657d7bd596a9a8538f1ff584f",
+        "version" : "0.1.3"
+      }
+    },
+    {
+      "identity" : "swiftformatlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Snapp-Mobile/SwiftFormatLintPlugin.git",
+      "state" : {
+        "revision" : "d34da87136323e245fd6cf33100b016500ecd803",
+        "version" : "1.0.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Example/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Example/Assets.xcassets/Contents.json
+++ b/Example/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  Example
+//
+//  Created by Volodymyr Voiko on 19.12.2025.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -5,20 +5,123 @@
 //  Created by Volodymyr Voiko on 19.12.2025.
 //
 
+import SnappDesignTokens
+import SnappTheming
+import SnappThemingDesignTokensSupport
 import SwiftUI
 
 struct ContentView: View {
+    @State var themeDeclaration: SnappThemingDeclaration?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        if let themeDeclaration {
+            content(themeDeclaration)
+        } else {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .task {
+                    await loadThemeDeclaration()
+                }
         }
-        .padding()
+    }
+
+    func content(_ theme: SnappThemingDeclaration) -> some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(theme.colors.keys, id: \.self) { key in
+                        LabeledContent(key) {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(theme.colors[dynamicMember: key])
+                                .frame(width: 40, height: 40)
+                                .shadow(color: .black.opacity(0.3), radius: 2)
+                        }
+                    }
+                } header: {
+                    Text("Colors")
+                }
+
+                Section {
+                    ForEach(theme.metrics.keys, id: \.self) { key in
+                        let value: CGFloat = theme.metrics[dynamicMember: key]
+                        LabeledContent(key) {
+                            HStack {
+                                Text(String(String(describing: value)))
+                                ZStack {
+                                    UnevenRoundedRectangle(
+                                        topLeadingRadius: value
+                                    )
+                                    .fill(Color.gray)
+                                    .padding([.top, .leading], value)
+                                }
+                                .frame(width: 40, height: 40)
+                                .background(Color.gray.secondary)
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Metrics")
+                }
+
+                Section {
+                    ForEach(theme.fonts.keys, id: \.self) { key in
+                        let fontInformation: SnappThemingFontInformation? = theme.fonts[dynamicMember: key]
+                        Text(fontInformation?.postScriptName ?? key)
+                            .font(fontInformation?.resolver.font(size: 16))
+                    }
+                } header: {
+                    Text("Fonts")
+                }
+
+                Section {
+                    ForEach(theme.typography.keys, id: \.self) { key in
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text(key)
+                            Text(
+                                "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                            )
+                            .font(theme.typography[dynamicMember: key])
+                        }
+                    }
+                } header: {
+                    Text("Typography")
+                }
+            }
+            .background(theme.colors.colorBackgroundPrimary)
+            .navigationTitle("Design Tokens Viewer")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .foregroundStyle(theme.colors.colorTextPrimary)
+    }
+
+    func loadThemeDeclaration() async {
+        let designTokensURL = Bundle.main.url(
+            forResource: "design.tokens",
+            withExtension: "json"
+        )!
+        let designTokens = try! String(
+            contentsOf: designTokensURL,
+            encoding: .utf8
+        )
+
+        themeDeclaration = try! await SnappThemingParser.parse(
+            fromDesignTokens: designTokens,
+            tokenProcessor: .combine(
+                .resolveAliases,
+                .skipKeys("base"),
+                .defaultDesignTokensFlatteingProcessor,
+                .defaultDesignTokensDimensionValueConversionProcessor
+            )
+        )
     }
 }
 
-#Preview {
+#Preview("Light") {
     ContentView()
+        .colorScheme(.light)
+}
+
+#Preview("Dark") {
+    ContentView()
+        .colorScheme(.dark)
 }

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  ExampleApp.swift
+//  Example
+//
+//  Created by Volodymyr Voiko on 19.12.2025.
+//
+
+import SwiftUI
+
+@main
+struct ExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Example/Example/design.tokens.json
+++ b/Example/Example/design.tokens.json
@@ -1,0 +1,146 @@
+{
+    "base": {
+        "color": {
+            "red": {
+                "$type": "color",
+                "$value": "#FF0000"
+            },
+            "green": {
+                "$type": "color",
+                "$value": "#00FF00"
+            },
+            "blue": {
+                "$type": "color",
+                "$value": "#0000FF"
+            },
+            "black": {
+                "$type": "color",
+                "$value": "#000000"
+            },
+            "white": {
+                "$type": "color",
+                "$value": "#FFFFFF"
+            }
+        },
+        "dimension": {
+            "spacing5": {
+                "$type": "dimension",
+                "$value": {
+                    "unit": "px",
+                    "value": 5
+                }
+            },
+            "spacing10": {
+                "$type": "dimension",
+                "$value": {
+                    "unit": "px",
+                    "value": 10
+                }
+            },
+            "spacing20": {
+                "$type": "dimension",
+                "$value": {
+                    "unit": "px",
+                    "value": 20
+                }
+            }
+        },
+        "fontFamily": {
+            "helveticaNeue": {
+                "$type": "fontFamily",
+                "$value": ["Helvetica Neue"]
+            },
+            "courierNew": {
+                "$type": "fontFamily",
+                "$value": ["Courier New"]
+            },
+        },
+        "fontSize": {
+            "body": {
+                "$type": "dimension",
+                "$value": {
+                    "unit": "rem",
+                    "value": 1
+                }
+            },
+            "h1": {
+                "$type": "dimension",
+                "$value": {
+                    "unit": "rem",
+                    "value": 2
+                }
+            }
+        },
+    },
+    "color": {
+        "primary": { "$value": "{base.color.red}" },
+        "secondary": { "$value": "{base.color.green}" },
+        "tertiary": { "$value": "{base.color.blue}" },
+        "text": {
+            "primary": {
+                "light": { "$value": "{base.color.black}" },
+                "dark": { "$value": "{base.color.white}" }
+            }
+        },
+        "background": {
+            "primary": {
+                "light": { "$value": "{base.color.white}" },
+                "dark": { "$value": "{base.color.black}" }
+            }
+        }
+    },
+    "spacing": {
+        "small": { "$value": "{base.dimension.spacing5}" },
+        "medium": { "$value": "{base.dimension.spacing10}" },
+        "large": { "$value": "{base.dimension.spacing20}" }
+    },
+    "fontFamily": {
+        "default": {
+            "$value": "{base.fontFamily.helveticaNeue}"
+        },
+        "monospaced": {
+            "$value": "{base.fontFamily.courierNew}"
+        }
+    },
+    "typography": {
+        "body": {
+            "$type": "typography",
+            "$value": {
+                "fontFamily": "{fontFamily.default}",
+                "fontSize": "{base.fontSize.body}",
+                "fontWeight": 400,
+                "letterSpacing": {
+                    "value": 0.1,
+                    "unit": "px"
+                },
+                "lineHeight": 1.2
+            }
+        },
+        "h1": {
+            "$type": "typography",
+            "$value": {
+                "fontFamily": "{fontFamily.default}",
+                "fontSize": "{base.fontSize.h1}",
+                "fontWeight": 700,
+                "letterSpacing": {
+                    "value": 0.1,
+                    "unit": "px"
+                },
+                "lineHeight": 1.2
+            }
+        },
+        "code": {
+            "$type": "typography",
+            "$value": {
+                "fontFamily": "{fontFamily.monospaced}",
+                "fontSize": "{base.fontSize.body}",
+                "fontWeight": 700,
+                "letterSpacing": {
+                    "value": 0.1,
+                    "unit": "px"
+                },
+                "lineHeight": 1.2
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
An example application (Example) has been added to demonstrate the usage of the `SnappThemingDesignTokensSupport` library, along with `SnappDesignTokens` and `SnappTheming`. The example app parses a `design.tokens.json` file and visually displays the extracted colors, metrics, fonts, and typography in a SwiftUI interface.

## Why
The addition of an example application provides a clear, practical demonstration of how to integrate and use the SnappThemingDesignTokensSupport library within a real-world project. It helps developers understand the workflow from a DTCG design.tokens.json file to a functional SwiftUI theme, showcasing the benefits of the theming ecosystem. This will serve as valuable documentation and a quick start guide for new users.

## Changes
* New Directory: Example/ containing a full Xcode project (Example.xcodeproj), SwiftUI application files (ExampleApp.swift, ContentView.swift), asset catalogs, and a sample design.tokens.json file.
* The Example project is configured to use SnappThemingDesignTokensSupport as a local Swift Package dependency.
* ContentView.swift demonstrates parsing design tokens, applying token processors, and rendering various themed UI elements (colors, metrics, fonts, typography) using SnappTheming.

# Screenshots

| Light | Dark |
| - | - |
| <img width="512" src="https://github.com/user-attachments/assets/e9ac13e4-37ec-4953-a691-e34ce8f8d8df" /> | <img width="512" src="https://github.com/user-attachments/assets/631f949b-94e2-4d28-9f62-25095722970d" /> | 
| <img width="512" src="https://github.com/user-attachments/assets/6df6c203-0e4b-4473-b6b1-8dbc1ccdcf8f" /> | <img width="512" src="https://github.com/user-attachments/assets/0a63cc95-eee4-4bbc-9161-0bb667e25006" /> |


